### PR TITLE
Surface memory context attachments and add admin helpers

### DIFF
--- a/utils/context.py
+++ b/utils/context.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Any
 
 def render_context(hits: List[Tuple[object, float]], max_chars: int = 2000) -> str:
     header = "## Context (top motifs)\n"
@@ -13,3 +13,40 @@ def render_context(hits: List[Tuple[object, float]], max_chars: int = 2000) -> s
         lines.append(chunk)
         used += len(chunk)
     return header + "".join(lines)
+
+
+def structured_hits(layer: str, hits: List[Tuple[object, float]]) -> List[Dict[str, Any]]:
+    """Return a serialisable representation of retrieval hits.
+
+    The Open WebUI host can surface this structure alongside the chat turn
+    without having to parse the Markdown context block.
+    """
+
+    out: List[Dict[str, Any]] = []
+    for motif, score in hits:
+        out.append(
+            {
+                "id": getattr(motif, "id", None),
+                "layer": layer,
+                "score": float(score),
+                "symbols": list(getattr(motif, "symbols", []) or []),
+                "content": getattr(motif, "content", ""),
+                "owner": getattr(motif, "metadata", {}).get("owner") if getattr(motif, "metadata", None) else None,
+            }
+        )
+    return out
+
+
+def attachment_payload(layer: str, hits: List[Tuple[object, float]]) -> Dict[str, Any]:
+    """Small helper to build a markdown attachment payload for the UI."""
+
+    block = render_context(hits).replace("## Context (top motifs)", f"## {layer.title()} memory", 1)
+    return {
+        "type": "markdown",
+        "title": f"{layer.title()} memory",  # Public / Personal
+        "content": block,
+        "meta": {
+            "layer": layer,
+            "hits": len(hits),
+        },
+    }


### PR DESCRIPTION
## Summary
- attach structured memory metadata and markdown attachments to chat events so Open WebUI can display retrieved context
- add admin-focused tool functions that expose memory links and gated namespace wipes for console panels
- extend context utilities to emit structured hit payloads shared by the filter and tools

## Testing
- python -m compileall filters tools utils

------
https://chatgpt.com/codex/tasks/task_b_68ea59cfb8a48325bcc2b446249f4cdf