### PR TITLE
Improve memory observability and linking safeguards

### DIFF
--- a/filters/dual_layer_memory_filter.py
+++ b/filters/dual_layer_memory_filter.py
@@ -49,8 +49,7 @@ def on_message(event: Dict[str, Any]) -> Dict[str, Any]:
         attachments = []
         structured: Dict[str, Any] = {}
 
-        r_pub = _store.router("public", None)
-        hits_pub = r_pub.search_text(text, top_k=max(0, k_pub))
+        hits_pub = _store.search_text("public", None, text, top_k=max(0, k_pub))
         if hits_pub:
             structured["public"] = structured_hits("public", hits_pub)
             attachments.append(attachment_payload("public", hits_pub))
@@ -58,8 +57,7 @@ def on_message(event: Dict[str, Any]) -> Dict[str, Any]:
             ctx_sections.append(block)
 
         if user_id and k_per > 0:
-            r_per = _store.router("personal", user_id)
-            hits_per = r_per.search_text(text, top_k=k_per)
+            hits_per = _store.search_text("personal", user_id, text, top_k=k_per)
             if hits_per:
                 structured["personal"] = structured_hits("personal", hits_per)
                 attachments.append(attachment_payload("personal", hits_per))

--- a/memory_config.yaml
+++ b/memory_config.yaml
@@ -12,12 +12,14 @@ policy:
     novelty_min: 0.20
     max_links_per_motif: 2
     symbol_jaccard_cap: 0.80
+    max_links_per_minute: 20
   personal:
     link_threshold: 0.60
     dedup_threshold: 0.93
     novelty_min: 0.10
     max_links_per_motif: 3
     symbol_jaccard_cap: 0.80
+    max_links_per_minute: 40
 retrieval:
   k_public: 5
   k_personal: 3

--- a/policy/runtime_policy.py
+++ b/policy/runtime_policy.py
@@ -8,12 +8,14 @@ class Policy:
         novelty_min: float = 0.10,
         max_links_per_motif: int = 3,
         symbol_jaccard_cap: float = 0.80,
+        max_links_per_minute: int = 30,
     ):
         self.link_threshold = link_threshold
         self.dedup_threshold = dedup_threshold
         self.novelty_min = novelty_min
         self.max_links_per_motif = max_links_per_motif
         self.symbol_jaccard_cap = symbol_jaccard_cap
+        self.max_links_per_minute = max(0, int(max_links_per_minute))
 
     def should_persist(self, novelty_index: float) -> bool:
         return novelty_index >= self.novelty_min

--- a/storage/chroma_store.py
+++ b/storage/chroma_store.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 from typing import List, Optional, Dict, Tuple
+import logging
+import threading
+from collections import defaultdict, deque
 import time, uuid, chromadb
 from chromadb.config import Settings
 from routing.chroma_router import ChromaRouter, Motif
 from policy.runtime_policy import Policy
+
+log = logging.getLogger(__name__)
 
 # ----------------- small helpers -----------------
 
@@ -64,6 +69,12 @@ class ChromaStore:
         self.personal_prefix = personal_prefix
         self.embedding_model = embedding_model
         self.allow_hash_fallback = allow_hash_fallback
+        self._router_lock = threading.RLock()
+        self._routers: Dict[Tuple[str, str], ChromaRouter] = {}
+        self._metrics_lock = threading.Lock()
+        self._metrics: Dict[str, Dict[str, float]] = defaultdict(lambda: {"count": 0, "errors": 0, "latency_ms": 0.0})
+        self._link_windows: Dict[Tuple[str, str], deque[float]] = defaultdict(deque)
+        self._link_window_seconds = 60.0
         try:
             self.client = chromadb.PersistentClient(path=persist_dir, settings=Settings(allow_reset=False))
         except Exception as exc:  # pragma: no cover - defensive
@@ -86,49 +97,164 @@ class ChromaStore:
             return self.client.create_collection(name, metadata={"hnsw:space": "cosine"})
 
     # ---- routers ----
+    def _observe(self, name: str, start: float, error: bool = False) -> float:
+        elapsed = (time.perf_counter() - start) * 1000.0
+        with self._metrics_lock:
+            stats = self._metrics[name]
+            stats["count"] += 1
+            if error:
+                stats["errors"] += 1
+            stats["latency_ms"] += elapsed
+        return elapsed
+
+    def metrics_snapshot(self) -> Dict[str, Dict[str, float]]:
+        with self._metrics_lock:
+            return {k: dict(v) for k, v in self._metrics.items()}
+
+    def _router_key(self, layer: str, user_id: Optional[str]) -> Tuple[str, str]:
+        return layer, (user_id or "__shared__")
+
     def router(self, layer: str, user_id: Optional[str]) -> ChromaRouter:
-        coll = self._motif_coll_name(layer, user_id)
-        r = ChromaRouter(
-            persist_dir=self.persist_dir,
-            collection_name=coll,
-            embedding_model=self.embedding_model,
-            allow_hash_fallback=self.allow_hash_fallback,
-        )
-        r.rebuild_cache()
-        return r
+        key = self._router_key(layer, user_id)
+        with self._router_lock:
+            router = self._routers.get(key)
+            if router is None:
+                coll = self._motif_coll_name(layer, user_id)
+                router = ChromaRouter(
+                    persist_dir=self.persist_dir,
+                    collection_name=coll,
+                    embedding_model=self.embedding_model,
+                    allow_hash_fallback=self.allow_hash_fallback,
+                )
+                router.rebuild_cache()
+                self._routers[key] = router
+        return router
+
+    def search_text(self, layer: str, user_id: Optional[str], text: str, top_k: int = 5):
+        start = time.perf_counter()
+        error = False
+        try:
+            router = self.router(layer, user_id)
+            return router.search_text(text, top_k=top_k)
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Search failed for layer=%s user_id=%s: %s", layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("search_text", start, error)
+            log.debug("memory.search_text layer=%s user=%s top_k=%s took %.2fms (error=%s)", layer, user_id, top_k, elapsed, error)
 
     # ---- CRUD: motifs ----
     def list_motifs(self, layer: str, user_id: Optional[str]):
-        r = self.router(layer, user_id)
-        return [{"id": m.id, "content": m.content, "symbols": m.symbols, "metadata": m.metadata} for m in r._cache.values()]
+        start = time.perf_counter()
+        error = False
+        try:
+            r = self.router(layer, user_id)
+            return [{"id": m.id, "content": m.content, "symbols": m.symbols, "metadata": m.metadata} for m in r._cache.values()]
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to list motifs for %s/%s: %s", layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("list_motifs", start, error)
+            log.debug("memory.list_motifs layer=%s user=%s took %.2fms (error=%s)", layer, user_id, elapsed, error)
 
     def upsert_motifs(self, layer: str, user_id: Optional[str], motifs: List[Motif]):
-        r = self.router(layer, user_id)
-        r.add_many(motifs)
+        start = time.perf_counter()
+        error = False
+        try:
+            r = self.router(layer, user_id)
+            r.add_many(motifs)
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to upsert motifs for %s/%s: %s", layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("upsert_motifs", start, error)
+            log.debug("memory.upsert_motifs layer=%s user=%s count=%s took %.2fms (error=%s)", layer, user_id, len(motifs), elapsed, error)
 
     def delete_motif(self, layer: str, user_id: Optional[str], motif_id: str):
-        self.router(layer, user_id).delete(motif_id)
+        start = time.perf_counter()
+        error = False
+        try:
+            self.router(layer, user_id).delete(motif_id)
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to delete motif %s for %s/%s: %s", motif_id, layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("delete_motif", start, error)
+            log.debug("memory.delete_motif layer=%s user=%s took %.2fms (error=%s)", layer, user_id, elapsed, error)
 
     # ---- CRUD: edges ----
+    def _consume_link_budget(self, layer: str, user_id: Optional[str], policy: Policy) -> bool:
+        limit = getattr(policy, "max_links_per_minute", 0)
+        if limit <= 0:
+            return True
+        key = self._router_key(layer, user_id)
+        window = self._link_windows[key]
+        now = time.time()
+        cutoff = now - self._link_window_seconds
+        while window and window[0] < cutoff:
+            window.popleft()
+        if len(window) >= limit:
+            return False
+        window.append(now)
+        return True
+
     def link(self, layer: str, user_id: Optional[str], src_id: str, dst_id: str, rel: str = "linked") -> None:
-        edges = self._get_or_create(self._edge_coll_name(layer, user_id))
-        eid = f"{src_id}__{rel}__{dst_id}"
-        edges.upsert(ids=[eid], documents=[""], metadatas=[{"src": src_id, "dst": dst_id, "rel": rel, "ts": time.time()}])
+        start = time.perf_counter()
+        error = False
+        try:
+            edges = self._get_or_create(self._edge_coll_name(layer, user_id))
+            eid = f"{src_id}__{rel}__{dst_id}"
+            edges.upsert(ids=[eid], documents=[""], metadatas=[{"src": src_id, "dst": dst_id, "rel": rel, "ts": time.time()}])
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to link %s -> %s for %s/%s: %s", src_id, dst_id, layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("link", start, error)
+            log.debug("memory.link layer=%s user=%s took %.2fms (error=%s)", layer, user_id, elapsed, error)
 
     def links_for(self, layer: str, user_id: Optional[str], motif_id: str) -> List[Dict]:
-        edges = self._get_or_create(self._edge_coll_name(layer, user_id))
-        res = edges.get(include=["ids","metadatas"], where={"src": motif_id})
-        out = []
-        for eid, meta in zip(res.get("ids", []), res.get("metadatas", [])):
-            out.append({"id": eid, **(meta or {})})
-        return out
+        start = time.perf_counter()
+        error = False
+        try:
+            edges = self._get_or_create(self._edge_coll_name(layer, user_id))
+            res = edges.get(include=["ids","metadatas"], where={"src": motif_id})
+            out = []
+            for eid, meta in zip(res.get("ids", []), res.get("metadatas", [])):
+                out.append({"id": eid, **(meta or {})})
+            return out
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to list links for motif %s in %s/%s: %s", motif_id, layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("links_for", start, error)
+            log.debug("memory.links_for layer=%s user=%s took %.2fms (error=%s)", layer, user_id, elapsed, error)
 
     def wipe_namespace(self, layer: str, user_id: Optional[str]):
-        for name in (self._motif_coll_name(layer, user_id), self._edge_coll_name(layer, user_id)):
-            try:
-                self.client.delete_collection(name)
-            except Exception:
-                pass
+        start = time.perf_counter()
+        error = False
+        try:
+            for name in (self._motif_coll_name(layer, user_id), self._edge_coll_name(layer, user_id)):
+                try:
+                    self.client.delete_collection(name)
+                except Exception:
+                    pass
+            key = self._router_key(layer, user_id)
+            with self._router_lock:
+                self._routers.pop(key, None)
+            self._link_windows.pop(key, None)
+        except Exception as exc:  # pragma: no cover - unexpected
+            error = True
+            log.exception("Failed to wipe namespace %s/%s: %s", layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("wipe_namespace", start, error)
+            log.debug("memory.wipe_namespace layer=%s user=%s took %.2fms (error=%s)", layer, user_id, elapsed, error)
 
     # ---- Policy-gated persist with novelty + thresholded links ----
     def _link_with_policy(self, layer: str, user_id: Optional[str], r: ChromaRouter, m: Motif, policy: Policy) -> int:
@@ -138,48 +264,66 @@ class ChromaStore:
             if cand.id == m.id:
                 continue
             jacc = _jaccard(m.symbols, cand.symbols)
-            if policy.should_link(score, jacc, linked):
-                self.link(layer, user_id, m.id, cand.id, rel="linked")
-                linked += 1
+            if not policy.should_link(score, jacc, linked):
+                continue
+            if not self._consume_link_budget(layer, user_id, policy):
+                log.debug(
+                    "memory.link budget exhausted for layer=%s user=%s; skipping remaining proposals", layer, user_id
+                )
+                break
+            self.link(layer, user_id, m.id, cand.id, rel="linked")
+            linked += 1
         return linked
 
     def persist_units(self, layer: str, user_id: Optional[str], units: List[Dict], policy: Policy) -> List[str]:
         if not units:
             return []
-        r = self.router(layer, user_id)
-        accepted: List[Motif] = []
-        ids: List[str] = []
+        start = time.perf_counter()
+        error = False
+        accepted_count = 0
+        try:
+            r = self.router(layer, user_id)
+            accepted: List[Motif] = []
+            ids: List[str] = []
 
-        for u in units:
-            mid = str(uuid.uuid4())
-            content = f"[{u.get('type','unit')}] {u.get('title','')}\n{u.get('content','')}".strip()
-            symbols = list(dict.fromkeys((u.get("symbols") or []) + [u.get("type","unit"), layer]))
-            meta = {"layer": layer, "owner": (user_id if layer == "personal" else None), "created_at": time.time(), "updated_at": time.time()}
-            m = Motif(mid, content, symbols, meta)
+            for u in units:
+                mid = str(uuid.uuid4())
+                content = f"[{u.get('type','unit')}] {u.get('title','')}\n{u.get('content','')}".strip()
+                symbols = list(dict.fromkeys((u.get("symbols") or []) + [u.get("type","unit"), layer]))
+                meta = {"layer": layer, "owner": (user_id if layer == "personal" else None), "created_at": time.time(), "updated_at": time.time()}
+                m = Motif(mid, content, symbols, meta)
 
-            # --- dedup (nearest neighbor) ---
-            hits = r.search_text(m.content, top_k=1)
-            top1 = float(hits[0][1]) if hits else 0.0
-            if policy.is_duplicate(top1):
-                # merge symbols into nearest motif, update and skip new
-                if hits:
-                    nearest = hits[0][0]
-                    nearest.symbols = sorted(set(nearest.symbols) | set(m.symbols))
-                    r.add_one(nearest)  # update tags on existing node
-                continue
+                # --- dedup (nearest neighbor) ---
+                hits = r.search_text(m.content, top_k=1)
+                top1 = float(hits[0][1]) if hits else 0.0
+                if policy.is_duplicate(top1):
+                    # merge symbols into nearest motif, update and skip new
+                    if hits:
+                        nearest = hits[0][0]
+                        nearest.symbols = sorted(set(nearest.symbols) | set(m.symbols))
+                        r.add_one(nearest)  # update tags on existing node
+                    continue
 
-            # --- novelty (real scoring) ---
-            n = _novelty_scores(r, m, k=5)
-            if not policy.should_persist(n["novelty_index"]):
-                continue
+                # --- novelty (real scoring) ---
+                n = _novelty_scores(r, m, k=5)
+                if not policy.should_persist(n["novelty_index"]):
+                    continue
 
-            accepted.append(m); ids.append(mid)
+                accepted.append(m); ids.append(mid)
 
-        # batch add accepted
-        if accepted:
-            r.add_many(accepted)
-            # thresholded linking (now that motifs exist)
-            for m in accepted:
-                self._link_with_policy(layer, user_id, r, m, policy)
+            # batch add accepted
+            if accepted:
+                r.add_many(accepted)
+                # thresholded linking (now that motifs exist)
+                for m in accepted:
+                    self._link_with_policy(layer, user_id, r, m, policy)
 
-        return ids
+            accepted_count = len(accepted)
+            return ids
+        except Exception as exc:
+            error = True
+            log.exception("Failed to persist motifs for %s/%s: %s", layer, user_id, exc)
+            raise
+        finally:
+            elapsed = self._observe("persist_units", start, error)
+            log.debug("memory.persist_units layer=%s user=%s accepted=%s took %.2fms (error=%s)", layer, user_id, accepted_count, elapsed, error)

--- a/tools/memory.py
+++ b/tools/memory.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Optional, Dict, Any, List
 from utils.context import render_context
 from storage.chroma_store import ChromaStore
-from routing.chroma_router import Motif
 from policy.runtime_policy import Policy
 from utils.config_loader import get_config
 
@@ -20,8 +19,7 @@ PUB = Policy(**_cfg["policy"]["public"])
 PER = Policy(**_cfg["policy"]["personal"])
 
 def retrieve(query: str, layer: str = "public", user_id: Optional[str] = None, k: int = 5) -> Dict[str, Any]:
-    r = _store.router(layer, user_id)
-    hits = r.search_text(query, top_k=max(1, k))
+    hits = _store.search_text(layer, user_id, query, top_k=max(1, k))
     return {
         "count": len(hits),
         "context": render_context(hits),

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -79,6 +79,9 @@ def validate_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
         max_links = section.get("max_links_per_motif")
         if not isinstance(max_links, int) or max_links < 0:
             errors.append(f"policy.{layer}.max_links_per_motif must be a non-negative integer")
+        rate_limit = section.get("max_links_per_minute", 30)
+        if not isinstance(rate_limit, int) or rate_limit < 0:
+            errors.append(f"policy.{layer}.max_links_per_minute must be a non-negative integer")
 
     retrieval = cfg.get("retrieval") or {}
     for key in ("k_public", "k_personal"):


### PR DESCRIPTION
## Summary
- reuse cached Chroma router instances and add latency/error instrumentation throughout the store
- expose a metrics snapshot helper and guard automatic linking with a per-namespace rate limit
- update configuration schema, defaults, and retrieval callers to exercise the new store API

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68ee43ad8fe08325841b227b4099ecb8